### PR TITLE
Set local 'singleplayer' variable:

### DIFF
--- a/goblin_traps.lua
+++ b/goblin_traps.lua
@@ -318,6 +318,8 @@ if setting == true then
 else
 	print("enable_tnt ~= true")
 end
+
+local singleplayer = minetest.is_singleplayer()
 if (not singleplayer and setting ~= true) or (singleplayer and setting == false) then
 	-- wimpier trap for non-tnt settings
 	minetest.register_abm({


### PR DESCRIPTION
Fixes undeclared global error:

The global 'singleplayer' does not appear to exist, perhaps it was removed in recent versions of Minetest? This change adds a local variable 'singleplayer' containing the value of 'minetest.is_singleplayer()'.