### PR TITLE
Replace deprecated methods

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -3,11 +3,11 @@ mobs_goblins = {}
 mobs_goblins.mod = "redo"
 
 -- Initial settings check
-local damage_enabled = minetest.setting_getbool("enable_damage") or true
-local peaceful_only = minetest.setting_getbool("only_peaceful_mobs") or false
-local enable_blood = minetest.setting_getbool("mobs_enable_blood") or true
-mobs_goblins.protected = tonumber(minetest.setting_get("mobs_spawn_protected")) or 0
-mobs_goblins.remove = minetest.setting_getbool("remove_far_mobs") or false
+local damage_enabled = minetest.settings:get_bool("enable_damage") or true
+local peaceful_only = minetest.settings:get_bool("only_peaceful_mobs") or false
+local enable_blood = minetest.settings:get_bool("mobs_enable_blood") or true
+mobs_goblins.protected = tonumber(minetest.settings:get("mobs_spawn_protected")) or 0
+mobs_goblins.remove = minetest.settings:get_bool("remove_far_mobs") or false
 
 function mobs_goblins:register_mob(name, def)
 	minetest.register_entity(name, {
@@ -1320,7 +1320,7 @@ function mobs_goblins:spawn_specific(name, nodes, neighbors, min_light, max_ligh
 				return
 			end
 
-			if minetest.setting_getbool("display_mob_spawn") then
+			if minetest.settings:get_bool("display_mob_spawn") then
 				minetest.chat_send_all("[mobs_goblins] Spawned "..name.." at "..minetest.pos_to_string(pos))
 			end
 
@@ -1696,7 +1696,7 @@ function mobs_goblins:feed_tame(self, clicker, feed_count, breed)
 	if follow_holding(self, clicker) then
 --print ("mmm, tasty")
 		-- take item
-		if not minetest.setting_getbool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			item:take_item()
 			clicker:set_wielded_item(item)
 		end

--- a/goblin_traps.lua
+++ b/goblin_traps.lua
@@ -312,7 +312,7 @@ minetest.register_abm({
 		end
 	end})
 
-local setting = minetest.setting_getbool("enable_tnt")
+local setting = minetest.settings:get_bool("enable_tnt")
 if setting == true then
 	print("enable_tnt = true")
 else

--- a/goblins.lua
+++ b/goblins.lua
@@ -186,14 +186,14 @@ mobs_goblins:register_mob("mobs_goblins:goblin_cobble", {
 			if hp > self.hp_max then hp = self.hp_max end
 			self.object:set_hp(hp)
 			-- take item
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
 
 		-- right clicking with gold lump drops random item from mobs_goblins.goblin_drops
 		elseif item:get_name() == "default:gold_lump" then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
@@ -305,14 +305,14 @@ mobs_goblins:register_mob("mobs_goblins:goblin_digger", {
 			if hp > self.hp_max then hp = self.hp_max end
 			self.object:set_hp(hp)
 			-- take item
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
 
 		-- right clicking with gold lump drops random item from mobs_goblins.goblin_drops
 		elseif item:get_name() == "default:gold_lump" then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
@@ -433,14 +433,14 @@ mobs_goblins:register_mob("mobs_goblins:goblin_coal", {
 			if hp > self.hp_max then hp = self.hp_max end
 			self.object:set_hp(hp)
 			-- take item
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
 
 		-- right clicking with gold lump drops random item from mobs_goblins.goblin_drops
 		elseif item:get_name() == "default:gold_lump" then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
@@ -554,14 +554,14 @@ mobs_goblins:register_mob("mobs_goblins:goblin_iron", {
 			if hp > self.hp_max then hp = self.hp_max end
 			self.object:set_hp(hp)
 			-- take item
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
 
 		-- right clicking with gold lump drops random item from mobs_goblins.goblin_drops
 		elseif item:get_name() == "default:gold_lump" then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
@@ -675,14 +675,14 @@ mobs_goblins:register_mob("mobs_goblins:goblin_copper", {
 			if hp > self.hp_max then hp = self.hp_max end
 			self.object:set_hp(hp)
 			-- take item
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
 
 		-- right clicking with gold lump drops random item from mobs_goblins.goblin_drops
 		elseif item:get_name() == "default:gold_lump" then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
@@ -795,14 +795,14 @@ mobs_goblins:register_mob("mobs_goblins:goblin_gold", {
 			if hp > self.hp_max then hp = self.hp_max end
 			self.object:set_hp(hp)
 			-- take item
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
 
 		-- right clicking with gold lump drops random item from mobs_goblins.goblin_drops
 		elseif item:get_name() == "default:gold_lump" then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
@@ -915,14 +915,14 @@ mobs_goblins:register_mob("mobs_goblins:goblin_diamond", {
 			if hp > self.hp_max then hp = self.hp_max end
 			self.object:set_hp(hp)
 			-- take item
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
 
 		-- right clicking with gold lump drops random item from mobs_goblins.goblin_drops
 		elseif item:get_name() == "default:gold_lump" then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
@@ -1033,14 +1033,14 @@ mobs_goblins:register_mob("mobs_goblins:goblin_king", {
 			if hp > self.hp_max then hp = self.hp_max end
 			self.object:set_hp(hp)
 			-- take item
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end
 
 		-- right clicking with gold lump drops random item from mobs_goblins.goblin_drops
 		elseif item:get_name() == "default:gold_lump" then
-			if not minetest.setting_getbool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				item:take_item()
 				clicker:set_wielded_item(item)
 			end

--- a/init.lua
+++ b/init.lua
@@ -6,6 +6,6 @@ dofile(path.."/api.lua")
 dofile(path.."/goblins.lua") -- TenPlus1 and FreeLikeGNU
 dofile(path.."/goblin_traps.lua")
 dofile(path.."/nodes.lua")
---if minetest.setting_get("log_mods") then
+--if minetest.settings:get("log_mods") then
 	minetest.log("action", "GOBLINS is lowdids!")
 --end


### PR DESCRIPTION
- 'setting_get' with 'settings:get'
- 'setting_getbool' with 'settings:get_bool'

May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267