### PR TITLE
Make sure that local 'nodef' is not 'nil' in 'do_env_damage' function

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -375,7 +375,7 @@ function mobs_goblins:register_mob(name, def)
 				pos.y = pos.y + 1
 
 				-- water
-				if self.water_damage ~= 0
+				if self.water_damage ~= 0 and nodef ~= nil
 				and nodef.groups.water then
 					self.object:set_hp(self.object:get_hp() - self.water_damage)
 					effect(pos, 5, "bubble.png")
@@ -383,7 +383,7 @@ function mobs_goblins:register_mob(name, def)
 				end
 
 				-- lava or fire
-				if self.lava_damage ~= 0
+				if self.lava_damage ~= 0 and nodef ~= nil
 				and (nodef.groups.lava or nod.name == "fire:basic_flame") then
 					self.object:set_hp(self.object:get_hp() - self.lava_damage)
 					effect(pos, 5, "fire_basic_flame.png")


### PR DESCRIPTION
Not sure if this is the correct/best solution, but was getting the following error on my server:
```
2017-06-08 17:46:49: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'default' in callback luaentity_Step(): ...tum-testing/mods/mobiles/aggressive/mobs_goblins/api.lua:391: attempt to index local 'nodef' (a nil value)
2017-06-08 17:46:49: ERROR[Main]: stack traceback:
2017-06-08 17:46:49: ERROR[Main]: 	...tum-testing/mods/mobiles/aggressive/mobs_goblins/api.lua:391: in function 'do_env_damage'
2017-06-08 17:46:49: ERROR[Main]: 	...tum-testing/mods/mobiles/aggressive/mobs_goblins/api.lua:457: in function <...tum-testing/mods/mobiles/aggressive/mobs_goblins/api.lua:208>
```